### PR TITLE
chore: move dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "@reach/combobox": "^0.7.3",
     "@rehooks/local-storage": "^2.1.1",
     "@rematch/core": "^1.3.0",
-    "@testing-library/jest-dom": "^4.2.4",
-    "@testing-library/react": "^9.4.0",
-    "@testing-library/user-event": "^7.1.2",
-    "@types/jest": "^25.1.2",
     "codesandbox": "^2.1.11",
     "coloreact": "^0.3.1",
     "copy-to-clipboard": "^3.2.1",
@@ -63,6 +59,10 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.1.1",
+    "@testing-library/react": "^9.4.0",
+    "@testing-library/user-event": "^8.1.0",
+    "@types/jest": "^25.1.2",
     "@types/lodash": "^4.14.149",
     "@types/lz-string": "^1.3.33",
     "@types/prettier": "^1.19.0",


### PR DESCRIPTION
This PR will move some dev dependencies that were added as runtime dependencies to the correct place.

Fixes #61 